### PR TITLE
Remove extra space after category filter

### DIFF
--- a/src/js/utils/Query.js
+++ b/src/js/utils/Query.js
@@ -79,7 +79,7 @@ function tokenize(text) {
 
 function extractText(fullText) {
   // prune out attribute:value elements
-  var text = fullText.replace(/\w+:[^'"\s]+|\w+:'[^']+'|\w+:"[^"]+"/g, '');
+  var text = fullText.replace(/\w+:[^'"\s]+\s?|\w+:'[^']+'\s?|\w+:"[^"]+"\s?/g, '');
   return text;
 }
 


### PR DESCRIPTION
Fix text search for individual resource category. 

When you have filter(s) selected & you type in the text search, you get extra spaces appended (see attached image). 
I modified the regex pattern in the `extractText` function to trim the extra space.

![screen shot 2015-12-10 at 11 43 13 pm](https://cloud.githubusercontent.com/assets/3210082/11740669/2b872ce8-9f98-11e5-885a-125f4dd8cb84.png)
