### PR TITLE
Update Header, change large attribute to size

### DIFF
--- a/src/js/components/Header.js
+++ b/src/js/components/Header.js
@@ -76,7 +76,7 @@ var IndexHeader = React.createClass({
 
     return (
       <Header className={classes.join(' ')}
-        fixed={this.props.fixed} pad="medium" justify="between" large={true}>
+        fixed={this.props.fixed} pad="medium" justify="between" size="large">
         {this.props.navControl}
         <span className={CLASS_ROOT + "__title"}>{this.props.label}</span>
         <Search className={CLASS_ROOT + "__search" + " flex"}


### PR DESCRIPTION
I've updated to Grommet 4.x & it looks like `large` attribute has been deprecated in favor of `size`
