### PR TITLE
Don't require filter, query, & sort on header component

### DIFF
--- a/src/js/components/Header.js
+++ b/src/js/components/Header.js
@@ -92,9 +92,9 @@ IndexHeader.propTypes = {
   fixed: PropTypes.bool,
   label: PropTypes.string.isRequired,
   navControl: PropTypes.node,
-  onFilter: PropTypes.func.isRequired, // (filters)
-  onQuery: PropTypes.func.isRequired, // (query)
-  onSort: PropTypes.func.isRequired, // (sort)
+  onFilter: PropTypes.func, // (filters)
+  onQuery: PropTypes.func, // (query)
+  onSort: PropTypes.func, // (sort)
   query: PropTypes.object, // Query
   result: IndexPropTypes.result,
   sort: PropTypes.string


### PR DESCRIPTION
onFilter, onQuery, onSort doesn't need to be required.

For example, I'm currently not using a sort so i'm required to pass in an empty function to get rid of the console warning. 

``` javascript
_onSort(sort) {}
```
