### PR TITLE
Add Bulk Operations menu on tile groups

### DIFF
--- a/src/js/components/BulkOperations.js
+++ b/src/js/components/BulkOperations.js
@@ -1,0 +1,16 @@
+// (C) Copyright 2014-2015 Hewlett Packard Enterprise Development LP
+
+import React, { PropTypes } from 'react';
+import Box from 'grommet/components/Box';
+
+export default function BulkOperations({content}) {
+  return (
+    <Box pad={{horizontal:'small'}}>
+      {content}
+    </Box>
+  );
+};
+
+BulkOperations.propTypes = {
+  content: PropTypes.element
+};

--- a/src/js/components/BulkOperations.js
+++ b/src/js/components/BulkOperations.js
@@ -16,6 +16,6 @@ export default function BulkOperations({component, items}) {
 };
 
 BulkOperations.propTypes = {
-  items: PropTypes.array,
-  component: PropTypes.func.isRequired
+  component: PropTypes.func.isRequired,
+  items: PropTypes.array
 };

--- a/src/js/components/BulkOperations.js
+++ b/src/js/components/BulkOperations.js
@@ -1,16 +1,21 @@
 // (C) Copyright 2014-2015 Hewlett Packard Enterprise Development LP
 
 import React, { PropTypes } from 'react';
+import Menu from 'grommet/components/Menu';
 import Box from 'grommet/components/Box';
 
-export default function BulkOperations({content}) {
+export default function BulkOperations({component, items}) {
+  const Component = component;
   return (
     <Box pad={{horizontal:'small'}}>
-      {content}
+      <Menu size="small" inline={false} dropAlign={{right: 'right'}} direction="column">
+        <Component items={items} />
+      </Menu>
     </Box>
   );
 };
 
 BulkOperations.propTypes = {
-  content: PropTypes.element
+  items: PropTypes.array,
+  component: PropTypes.func.isRequired
 };

--- a/src/js/components/Index.js
+++ b/src/js/components/Index.js
@@ -131,13 +131,13 @@ export default class Index extends Component {
 Index.propTypes = {
   addControl: PropTypes.node,
   attributes: IndexPropTypes.attributes,
+  bulkOperationsComponent: PropTypes.func,
   emptyMessage: PropTypes.string,
   emptyAddControl: PropTypes.node,
   fill: PropTypes.bool, // for Tiles
   filter: PropTypes.object, // { name: [value, ...] }
   fixed: PropTypes.bool,
   flush: PropTypes.bool, // for Tiles
-  bulkOperationsComponent: PropTypes.func,
   itemComponent: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.shape({

--- a/src/js/components/Index.js
+++ b/src/js/components/Index.js
@@ -137,7 +137,7 @@ Index.propTypes = {
   filter: PropTypes.object, // { name: [value, ...] }
   fixed: PropTypes.bool,
   flush: PropTypes.bool, // for Tiles
-  bulkOperationsComponent: PropTypes.element,
+  bulkOperationsComponent: PropTypes.func,
   itemComponent: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.shape({

--- a/src/js/components/Index.js
+++ b/src/js/components/Index.js
@@ -111,6 +111,7 @@ export default class Index extends Component {
               fill={this.props.fill}
               flush={this.props.flush}
               itemComponent={itemComponent}
+              bulkOperationsComponent={this.props.bulkOperationsComponent}
               result={this.props.result}
               sections={this.props.sections}
               selection={this.props.selection}
@@ -136,6 +137,7 @@ Index.propTypes = {
   filter: PropTypes.object, // { name: [value, ...] }
   fixed: PropTypes.bool,
   flush: PropTypes.bool, // for Tiles
+  bulkOperationsComponent: PropTypes.element,
   itemComponent: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.shape({

--- a/src/js/components/Tiles.js
+++ b/src/js/components/Tiles.js
@@ -7,6 +7,7 @@ import Footer from 'grommet/components/Footer';
 import Box from 'grommet/components/Box';
 import Attribute from './Attribute';
 import IndexPropTypes from '../utils/PropTypes';
+import BulkOperations from './BulkOperations';
 
 const CLASS_ROOT = 'index-tiles';
 
@@ -111,7 +112,7 @@ export default class IndexTiles extends Component {
   }
 
   _renderSections (classes, onMore) {
-    const { result, selection, sort } = this.props;
+    const { result, selection, sort, bulkOperationsComponent } = this.props;
     const parts = sort.split(':');
     const attributeName = parts[0];
     const direction = parts[1];
@@ -166,7 +167,10 @@ export default class IndexTiles extends Component {
           sections.push(
             <div key={section.label} className={`${CLASS_ROOT}__section`}>
               <label>{section.label}</label>
-              {content}
+              <Box direction="row" pad={{between: 'small'}}>
+                {content}
+                <BulkOperations content={bulkOperationsComponent}/>
+              </Box>
             </div>
           );
         } else {
@@ -183,7 +187,7 @@ export default class IndexTiles extends Component {
   }
 
   _renderTiles (classes, onMore) {
-    const { result, selection } = this.props;
+    const { result, selection, bulkOperationsComponent } = this.props;
     let tiles;
     let selectionIndex;
     if (result && result.items) {
@@ -196,13 +200,16 @@ export default class IndexTiles extends Component {
     }
 
     return (
-      <Tiles className={classes.join(' ')} onMore={onMore}
-        flush={this.props.flush} fill={this.props.fill}
-        selectable={this.props.onSelect ? true : false}
-        selected={selectionIndex}
-        size={this.props.size}>
-        {tiles}
-      </Tiles>
+      <Box direction="row"  pad={{between: 'small'}}>
+        <Tiles className={classes.join(' ')} onMore={onMore}
+          flush={this.props.flush} fill={this.props.fill}
+          selectable={this.props.onSelect ? true : false}
+          selected={selectionIndex}
+          size={this.props.size}>
+          {tiles}
+        </Tiles>
+        <BulkOperations content={bulkOperationsComponent}/>
+      </Box>
     );
   }
 
@@ -231,6 +238,7 @@ IndexTiles.propTypes = {
   attributes: IndexPropTypes.attributes,
   fill: PropTypes.bool,
   flush: PropTypes.bool,
+  bulkOperationsComponent: PropTypes.element,
   itemComponent: PropTypes.oneOfType([
     PropTypes.object,
     PropTypes.func

--- a/src/js/components/Tiles.js
+++ b/src/js/components/Tiles.js
@@ -128,21 +128,28 @@ export default class IndexTiles extends Component {
       let tiles = [];
       let sectionItems = [];
 
-      items.forEach(item => {
-        let itemValue = item[attributeName];
-
+      while (items.length > 0) {
+        const item = items[0];
+        let itemValue = (item.hasOwnProperty(attributeName) ?
+          item[attributeName] : item.attributes[attributeName]);
+        if (itemValue instanceof Date) {
+          itemValue = itemValue.getTime();
+        }
         if (undefined === sectionValue ||
           ('asc' === direction && itemValue < sectionValue) ||
           ('desc' === direction && itemValue > sectionValue)) {
           // add it
+          items.shift();
           if (selection && item.uri === selection) {
             selectionIndex = tiles.length;
           }
           sectionItems.push(item);
           tiles.push(this._renderTile(item));
+        } else {
+          // done
+          break;
         }
-      });
-
+      }
 
       if (tiles.length > 0) {
         // only use onMore for last section

--- a/src/js/components/Tiles.js
+++ b/src/js/components/Tiles.js
@@ -24,7 +24,7 @@ class IndexTile extends Component {
     attributes.forEach(function (attribute) {
       var value = (
         <Attribute key={attribute.name}
-          item={item} attribute={attribute} />
+                   item={item} attribute={attribute} />
       );
       if ('status' === attribute.name) {
         statusValue = value;
@@ -53,10 +53,10 @@ class IndexTile extends Component {
 
     return (
       <Tile key={item.uri} align="start"
-        pad={{horizontal: "medium", vertical: "small"}}
-        direction="row" responsive={false}
-        onClick={onClick} selected={selected}
-        a11yTitle={`Open ${headerValues}`}>
+            pad={{horizontal: "medium", vertical: "small"}}
+            direction="row" responsive={false}
+            onClick={onClick} selected={selected}
+            a11yTitle={`Open ${headerValues}`}>
         {statusValue}
         <Box key="contents" direction="column">
           {header}
@@ -101,12 +101,12 @@ export default class IndexTiles extends Component {
       const Component = itemComponent;
       tile = (
         <Component key={item.uri} item={item} onClick={onClick}
-          selected={selected} />
+                   selected={selected} />
       );
     } else {
       tile = (
         <IndexTile key={item.uri} item={item} onClick={onClick}
-          selected={selected} attributes={this.props.attributes} />
+                   selected={selected} attributes={this.props.attributes} />
       );
     }
     return tile;
@@ -149,11 +149,11 @@ export default class IndexTiles extends Component {
         // only use onMore for last section
         let sectionTiles = (
           <Tiles key={section.label}
-            onMore={items.length === 0 ? onMore : undefined}
-            flush={this.props.flush} fill={this.props.fill}
-            selectable={this.props.onSelect ? true : false}
-            selected={selectionIndex}
-            size={this.props.size}>
+                 onMore={items.length === 0 ? onMore : undefined}
+                 flush={this.props.flush} fill={this.props.fill}
+                 selectable={this.props.onSelect ? true : false}
+                 selected={selectionIndex}
+                 size={this.props.size}>
             {tiles}
           </Tiles>
         );
@@ -164,7 +164,7 @@ export default class IndexTiles extends Component {
         if (bulkOperationsComponent) {
           bulkOperationsContent = <BulkOperations items={sectionItems} component={bulkOperationsComponent}/>;
           sectionContent = (
-            <Box key={section.label} direction="row" pad={{between: 'small'}}>
+            <Box key={section.label} direction="row" pad={{between: 'small'}} responsive={false}>
               {sectionTiles}
               {bulkOperationsContent}
             </Box>
@@ -214,10 +214,10 @@ export default class IndexTiles extends Component {
     return (
       <Box direction="row"  pad={{between: 'small'}}>
         <Tiles className={classes.join(' ')} onMore={onMore}
-          flush={this.props.flush} fill={this.props.fill}
-          selectable={this.props.onSelect ? true : false}
-          selected={selectionIndex}
-          size={this.props.size}>
+               flush={this.props.flush} fill={this.props.fill}
+               selectable={this.props.onSelect ? true : false}
+               selected={selectionIndex}
+               size={this.props.size}>
           {tiles}
         </Tiles>
         {bulkOperationsContent}
@@ -267,3 +267,4 @@ IndexTiles.propTypes = {
   ]),
   size: PropTypes.oneOf(['small', 'medium', 'large'])
 };
+

--- a/src/js/components/Tiles.js
+++ b/src/js/components/Tiles.js
@@ -8,6 +8,7 @@ import Box from 'grommet/components/Box';
 import Attribute from './Attribute';
 import IndexPropTypes from '../utils/PropTypes';
 import BulkOperations from './BulkOperations';
+import Menu from 'grommet/components/Menu';
 
 const CLASS_ROOT = 'index-tiles';
 
@@ -169,7 +170,7 @@ export default class IndexTiles extends Component {
               <label>{section.label}</label>
               <Box direction="row" pad={{between: 'small'}}>
                 {content}
-                <BulkOperations content={bulkOperationsComponent}/>
+                <BulkOperations items={items} content={bulkOperationsComponent}/>
               </Box>
             </div>
           );
@@ -199,6 +200,12 @@ export default class IndexTiles extends Component {
       }, this);
     }
 
+    let bulkOperationsContent;
+
+    if (bulkOperationsComponent) {
+      bulkOperationsContent = <BulkOperations items={result.items} component={bulkOperationsComponent}/>
+    }
+
     return (
       <Box direction="row"  pad={{between: 'small'}}>
         <Tiles className={classes.join(' ')} onMore={onMore}
@@ -208,7 +215,7 @@ export default class IndexTiles extends Component {
           size={this.props.size}>
           {tiles}
         </Tiles>
-        <BulkOperations content={bulkOperationsComponent}/>
+        {bulkOperationsContent}
       </Box>
     );
   }
@@ -238,7 +245,7 @@ IndexTiles.propTypes = {
   attributes: IndexPropTypes.attributes,
   fill: PropTypes.bool,
   flush: PropTypes.bool,
-  bulkOperationsComponent: PropTypes.element,
+  bulkOperationsComponent: PropTypes.func,
   itemComponent: PropTypes.oneOfType([
     PropTypes.object,
     PropTypes.func

--- a/src/js/components/Tiles.js
+++ b/src/js/components/Tiles.js
@@ -218,12 +218,12 @@ export default class IndexTiles extends Component {
     }
 
     return (
-      <Box direction="row"  pad={{between: 'small'}} responsive={false}>
+      <Box direction="row" pad={{between: 'small'}} responsive={false}>
         <Tiles className={classes.join(' ')} onMore={onMore}
-               flush={this.props.flush} fill={this.props.fill}
-               selectable={this.props.onSelect ? true : false}
-               selected={selectionIndex}
-               size={this.props.size}>
+          flush={this.props.flush} fill={this.props.fill}
+          selectable={this.props.onSelect ? true : false}
+          selected={selectionIndex}
+          size={this.props.size}>
           {tiles}
         </Tiles>
         {bulkOperationsContent}
@@ -254,9 +254,9 @@ export default class IndexTiles extends Component {
 
 IndexTiles.propTypes = {
   attributes: IndexPropTypes.attributes,
+  bulkOperationsComponent: PropTypes.func,
   fill: PropTypes.bool,
   flush: PropTypes.bool,
-  bulkOperationsComponent: PropTypes.func,
   itemComponent: PropTypes.oneOfType([
     PropTypes.object,
     PropTypes.func

--- a/src/js/components/Tiles.js
+++ b/src/js/components/Tiles.js
@@ -127,32 +127,27 @@ export default class IndexTiles extends Component {
         sectionValue = sectionValue.getTime();
       }
       let tiles = [];
+      let sectionItems = [];
 
-      while (items.length > 0) {
-        const item = items[0];
-        let itemValue = (item.hasOwnProperty(attributeName) ?
-          item[attributeName] : item.attributes[attributeName]);
-        if (itemValue instanceof Date) {
-          itemValue = itemValue.getTime();
-        }
+      items.forEach(item => {
+        let itemValue = item[attributeName];
+
         if (undefined === sectionValue ||
           ('asc' === direction && itemValue < sectionValue) ||
           ('desc' === direction && itemValue > sectionValue)) {
           // add it
-          items.shift();
           if (selection && item.uri === selection) {
             selectionIndex = tiles.length;
           }
+          sectionItems.push(item);
           tiles.push(this._renderTile(item));
-        } else {
-          // done
-          break;
         }
-      }
+      });
+
 
       if (tiles.length > 0) {
         // only use onMore for last section
-        let content = (
+        let sectionTiles = (
           <Tiles key={section.label}
             onMore={items.length === 0 ? onMore : undefined}
             flush={this.props.flush} fill={this.props.fill}
@@ -163,19 +158,29 @@ export default class IndexTiles extends Component {
           </Tiles>
         );
 
+        let bulkOperationsContent;
+        let sectionContent = sectionTiles;
+
+        if (bulkOperationsComponent) {
+          bulkOperationsContent = <BulkOperations items={sectionItems} component={bulkOperationsComponent}/>;
+          sectionContent = (
+            <Box key={section.label} direction="row" pad={{between: 'small'}}>
+              {sectionTiles}
+              {bulkOperationsContent}
+            </Box>
+          );
+        }
+
         if (sections.length !== 0 || items.length !== 0) {
           // more than one section, add label
           sections.push(
             <div key={section.label} className={`${CLASS_ROOT}__section`}>
               <label>{section.label}</label>
-              <Box direction="row" pad={{between: 'small'}}>
-                {content}
-                <BulkOperations items={items} content={bulkOperationsComponent}/>
-              </Box>
+              {sectionContent}
             </div>
           );
         } else {
-          sections.push(content);
+          sections.push(sectionContent);
         }
       }
     });

--- a/src/js/components/Tiles.js
+++ b/src/js/components/Tiles.js
@@ -218,7 +218,7 @@ export default class IndexTiles extends Component {
     }
 
     return (
-      <Box direction="row"  pad={{between: 'small'}}>
+      <Box direction="row"  pad={{between: 'small'}} responsive={false}>
         <Tiles className={classes.join(' ')} onMore={onMore}
                flush={this.props.flush} fill={this.props.fill}
                selectable={this.props.onSelect ? true : false}

--- a/src/js/components/Tiles.js
+++ b/src/js/components/Tiles.js
@@ -8,7 +8,6 @@ import Box from 'grommet/components/Box';
 import Attribute from './Attribute';
 import IndexPropTypes from '../utils/PropTypes';
 import BulkOperations from './BulkOperations';
-import Menu from 'grommet/components/Menu';
 
 const CLASS_ROOT = 'index-tiles';
 
@@ -24,7 +23,7 @@ class IndexTile extends Component {
     attributes.forEach(function (attribute) {
       var value = (
         <Attribute key={attribute.name}
-                   item={item} attribute={attribute} />
+          item={item} attribute={attribute} />
       );
       if ('status' === attribute.name) {
         statusValue = value;
@@ -53,10 +52,10 @@ class IndexTile extends Component {
 
     return (
       <Tile key={item.uri} align="start"
-            pad={{horizontal: "medium", vertical: "small"}}
-            direction="row" responsive={false}
-            onClick={onClick} selected={selected}
-            a11yTitle={`Open ${headerValues}`}>
+        pad={{horizontal: "medium", vertical: "small"}}
+        direction="row" responsive={false}
+        onClick={onClick} selected={selected}
+        a11yTitle={`Open ${headerValues}`}>
         {statusValue}
         <Box key="contents" direction="column">
           {header}
@@ -101,12 +100,12 @@ export default class IndexTiles extends Component {
       const Component = itemComponent;
       tile = (
         <Component key={item.uri} item={item} onClick={onClick}
-                   selected={selected} />
+          selected={selected} />
       );
     } else {
       tile = (
         <IndexTile key={item.uri} item={item} onClick={onClick}
-                   selected={selected} attributes={this.props.attributes} />
+          selected={selected} attributes={this.props.attributes} />
       );
     }
     return tile;
@@ -149,11 +148,11 @@ export default class IndexTiles extends Component {
         // only use onMore for last section
         let sectionTiles = (
           <Tiles key={section.label}
-                 onMore={items.length === 0 ? onMore : undefined}
-                 flush={this.props.flush} fill={this.props.fill}
-                 selectable={this.props.onSelect ? true : false}
-                 selected={selectionIndex}
-                 size={this.props.size}>
+            onMore={items.length === 0 ? onMore : undefined}
+            flush={this.props.flush} fill={this.props.fill}
+            selectable={this.props.onSelect ? true : false}
+            selected={selectionIndex}
+            size={this.props.size}>
             {tiles}
           </Tiles>
         );
@@ -208,7 +207,7 @@ export default class IndexTiles extends Component {
     let bulkOperationsContent;
 
     if (bulkOperationsComponent) {
-      bulkOperationsContent = <BulkOperations items={result.items} component={bulkOperationsComponent}/>
+      bulkOperationsContent = <BulkOperations items={result.items} component={bulkOperationsComponent}/>;
     }
 
     return (


### PR DESCRIPTION
Adds a prop of `bulkOperationsComponent` that will be rendered inside of an inline menu. grommet-index passes back the items in the group that can be operated on.
