### PR TITLE
Adding class element to the filter body.

### DIFF
--- a/src/js/components/Filter.js
+++ b/src/js/components/Filter.js
@@ -82,7 +82,7 @@ export default class Filter extends Component {
       );
     }
     return (
-      <Box direction="column" pad={{between: 'small'}}>
+      <Box direction="column" pad={{between: 'small'}} className={`${CLASS_ROOT}__body`}>
         {checkBoxes}
       </Box>
     );

--- a/src/scss/grommet-index/_objects.index-filter.scss
+++ b/src/scss/grommet-index/_objects.index-filter.scss
@@ -11,3 +11,8 @@
     border-color: $focus-border-color;
   }
 }
+
+.index-filter__body {
+  max-height: $size-xsmall;
+  overflow-y: auto;
+}


### PR DESCRIPTION
This helps styling the size of the filter body. Allows to specify a size and scrollbar for filters with long lists of option.

Usage example
This example uses Box and tag prop together with the class to achieve a max length filter with a scroll bar (when needed)

code

<Box tag="facetfilter">
  <Filter onChange=... all=... key=... name=... active=... exclusive=... label=... inline=... choices=... />
</Box>

... custome css for the filter under the box

facetfilter .index-filter__body {
  max-height: $size-xsmall;
  overflow-y: auto;
}

@alansouzati , @ericsoderberghp could you please review, thanks Xabier P.
