### PR TITLE
Fix IE11 Split sizing

### DIFF
--- a/src/scss/grommet-index/_objects.index.scss
+++ b/src/scss/grommet-index/_objects.index.scss
@@ -1,7 +1,6 @@
 // (C) Copyright 2014-2015 Hewlett Packard Enterprise Development LP
 
 .index {
-  min-width: $sidebar-width;
   max-width: 100%;
   overflow: auto;
 


### PR DESCRIPTION
Fixes grommet/grommet#652.

Currently in IE11:
![image](https://cloud.githubusercontent.com/assets/3210082/16538195/064d7700-3fb8-11e6-9337-ce2f2e5e9dd1.png)

Fixed screenshot:
![image](https://cloud.githubusercontent.com/assets/3210082/16538196/216db54a-3fb8-11e6-99ab-08949c9cdde8.png)
