### PR TITLE
Adding instructional attribute

### DIFF
--- a/src/js/components/Filter.js
+++ b/src/js/components/Filter.js
@@ -82,7 +82,7 @@ export default class Filter extends Component {
       );
     }
     return (
-      <Box direction="column" pad={{between: 'small'}}>
+      <Box direction="column" pad={{between: 'small'}} className={`${CLASS_ROOT}__body`}>
         {checkBoxes}
       </Box>
     );

--- a/src/js/components/Index.js
+++ b/src/js/components/Index.js
@@ -9,6 +9,7 @@ import IndexTiles from './Tiles';
 import IndexList from './List';
 import IndexHeader from './Header';
 import Intl from 'grommet/utils/Intl';
+import { isMobile } from '../utils/helpers';
 
 const CLASS_ROOT = 'index';
 
@@ -98,6 +99,15 @@ export default class Index extends Component {
     }
     const ViewComponent = VIEW_COMPONENT[view];
 
+    let instructional;
+    if (this.props.instructional && !isMobile) {
+      instructional = (
+        <Box size="medium" pad={{horizontal: 'large', vertical: 'small'}}>
+          {this.props.instructional}
+        </Box>
+      );
+    }
+
     return (
       <div className={classes.join(' ')}>
         <div className={`${CLASS_ROOT}__container`}>
@@ -111,7 +121,9 @@ export default class Index extends Component {
             data={data}
             fixed={this.props.fixed}
             addControl={this.props.addControl}
+            instructional={this.props.instructional}
             navControl={this.props.navControl} />
+          {instructional}
           {error}
           {notifications}
           <div ref="items" className={`${CLASS_ROOT}__items`}>
@@ -159,6 +171,7 @@ Index.propTypes = {
   label: PropTypes.string,
   navControl: PropTypes.node,
   notifications: PropTypes.node,
+  instructional: PropTypes.node,
   onFilter: PropTypes.func, // (filter)
   onMore: PropTypes.func,
   onQuery: PropTypes.func, // (query)

--- a/src/js/utils/helpers.js
+++ b/src/js/utils/helpers.js
@@ -1,0 +1,15 @@
+// (C) Copyright 2014-2015 Hewlett Packard Enterprise Development LP
+
+export const isMobile = (() => {
+
+  let hasTouchScreen = false;
+
+  try {
+    hasTouchScreen = typeof window.orientation !== 'undefined';
+  } catch (e) {
+    console.warn(e);
+  }
+
+  return hasTouchScreen;
+})();
+

--- a/src/scss/grommet-index/_objects.index-filter.scss
+++ b/src/scss/grommet-index/_objects.index-filter.scss
@@ -11,3 +11,8 @@
     border-color: $focus-border-color;
   }
 }
+
+.index-filter__body {
+  max-height: $size-xsmall;
+  overflow-y: auto;
+}


### PR DESCRIPTION
Allows users to add an instructional element or text underneath the `<IndexHeader/>` component, that will only show for desktop versions.

`instructional = PropType.node`

Added `utils/helpers` which contains a function that checks for mobile devices, and returns a boolean.
