### PR TITLE
Change Header query propType to be an instance of Query

### DIFF
--- a/src/js/components/Header.js
+++ b/src/js/components/Header.js
@@ -105,7 +105,7 @@ IndexHeader.propTypes = {
   onFilter: PropTypes.func, // (filters)
   onQuery: PropTypes.func, // (query)
   onSort: PropTypes.func, // (sort)
-  query: PropTypes.object, // Query
+  query: PropTypes.instanceOf(IndexQuery), // instance of Query
   data: IndexPropTypes.data,
   sort: PropTypes.string
 };


### PR DESCRIPTION
`query` should not be a string nor an object, it should be an instance of `Query` (`grommet-index/utils/Query`). 
Resolves #24. 
