### PR TITLE
allow any node in emptyMessage prop

### DIFF
--- a/src/js/components/Index.js
+++ b/src/js/components/Index.js
@@ -142,7 +142,7 @@ Index.propTypes = {
   addControl: PropTypes.node,
   attributes: IndexPropTypes.attributes,
   data: IndexPropTypes.data,
-  emptyMessage: PropTypes.string,
+  emptyMessage: PropTypes.node,
   emptyAddControl: PropTypes.node,
   fill: PropTypes.bool, // for Tiles
   filter: PropTypes.object, // { name: [value, ...] }


### PR DESCRIPTION
Allow any node to be used in the `emptyMessage` prop instead of limiting to strings. This allows for insertion of headings, paragraphs, links, etc.
