### PR TITLE
Ability to render filters as sidebar instead of menu

### DIFF
--- a/src/js/components/Filters.js
+++ b/src/js/components/Filters.js
@@ -108,6 +108,8 @@ export default class Filters extends Component {
       classNames.push(this.props.className);
     }
 
+    const filterOrSortAttributes = attributes.filter(a => a.filter || a.sort);
+
     const filters = attributes
       .filter(attribute => attribute.hasOwnProperty('filter'))
       .map(attribute => this._renderFilter(attribute));
@@ -118,11 +120,12 @@ export default class Filters extends Component {
     }
 
     let result;
-
-    if (inline) {
-      result = this.renderSidebar({filters, sort, classNames});
-    } else {
-      result = this.renderMenu({filters, sort, classNames});
+    if (filterOrSortAttributes.length > 0) {
+      if (inline) {
+        result = this.renderSidebar({filters, sort, classNames});
+      } else {
+        result = this.renderMenu({filters, sort, classNames});
+      }
     }
 
     return result;

--- a/src/js/components/Filters.js
+++ b/src/js/components/Filters.js
@@ -1,10 +1,13 @@
 // (C) Copyright 2014-2015 Hewlett Packard Enterprise Development LP
 
 import React, { Component, PropTypes } from 'react';
+import classnames from 'classnames';
 import Menu from 'grommet/components/Menu';
 import Box from 'grommet/components/Box';
 import Sidebar from 'grommet/components/Sidebar';
 import FilterIcon from 'grommet/components/icons/base/Filter';
+import Header from 'grommet/components/Header';
+import Button from 'grommet/components/Button';
 import Filter from './Filter';
 import Sort from './Sort';
 import Intl from 'grommet/utils/Intl';
@@ -43,6 +46,25 @@ export default class Filters extends Component {
     );
   }
 
+  _renderCounts () {
+    const { data } = this.props;
+
+    const countClasses = classnames(`${CLASS_ROOT}__count`, {
+      [`${CLASS_ROOT}__count--active`]: data.unfilteredTotal > data.total
+    });
+
+    return (
+      <div>
+        <span className={`${CLASS_ROOT}__total`}>
+          {data.unfilteredTotal}
+        </span>
+        <span className={countClasses}>
+          {data.total}
+        </span>
+      </div>
+    );
+  }
+
   _renderSort () {
     const { attributes, sort } = this.props;
     // prune to just attributes that we should sort
@@ -57,16 +79,21 @@ export default class Filters extends Component {
     return result;
   }
 
-  renderMenu ({ filters, sort, classNames }) {
-    const { values, direction } = this.props;
-
-    let a11yTitle = Intl.getMessage(this.context.intl, 'Filter');
+  _renderIcon() {
+    const { values } = this.props;
     const selectedFilterCount = Object.keys(values).length;
-    const icon = (
-      <FilterIcon colorIndex={selectedFilterCount ? 'brand' : undefined} />
-    );
     return (
-      <div>
+      <FilterIcon size="large" colorIndex={selectedFilterCount ? 'brand' : undefined} />
+    );
+  }
+
+  _renderMenu ({ filters, sort, classNames }) {
+    const { direction } = this.props;
+    const a11yTitle = Intl.getMessage(this.context.intl, 'Filter');
+    const icon = this._renderIcon();
+
+    return (
+      <div className={`${CLASS_ROOT}__filters no-flex`}>
         <Menu className={CLASS_ROOT + "__menu"} icon={icon}
           dropAlign={{right: 'right'}} a11yTitle={a11yTitle}
           direction="column" closeOnClick={false}>
@@ -77,16 +104,24 @@ export default class Filters extends Component {
             {sort}
           </Box>
         </Menu>
-        {this.props.filterCounts}
+        {this._renderCounts()}
       </div>
     );
   }
 
-  renderSidebar ({ filters, sort, classNames }) {
+  _renderSidebar ({ filters, sort, classNames }) {
     const { direction } = this.props;
+    const icon = this._renderIcon();
+
     return (
       <Sidebar colorIndex="light-2">
-      {this.props.headingComponent}
+        <Header size="large" pad={{horizontal: 'medium'}} justify="between">
+          {Intl.getMessage(this.context.intl, 'Filter by')}
+          <div className={`${CLASS_ROOT}__filters no-flex`}>
+            <Button icon={icon} plain={true} onClick={this.props.onClose}/>
+            {this._renderCounts()}
+            </div>
+        </Header>
         <Box
           direction={direction}
           pad={{horizontal: 'large', vertical: 'medium', between: 'medium'}}
@@ -122,9 +157,9 @@ export default class Filters extends Component {
     let result;
     if (filterOrSortAttributes.length > 0) {
       if (inline) {
-        result = this.renderSidebar({filters, sort, classNames});
+        result = this._renderSidebar({filters, sort, classNames});
       } else {
-        result = this.renderMenu({filters, sort, classNames});
+        result = this._renderMenu({filters, sort, classNames});
       }
     }
 

--- a/src/js/components/Filters.js
+++ b/src/js/components/Filters.js
@@ -91,18 +91,13 @@ export default class Filters extends Component {
       );
     } else {
       classNames.push(`${CLASS_ROOT}__drop`);
-      let a11yTitle = Intl.getMessage(this.context.intl, 'Filter');
       result = (
-        <Menu className={CLASS_ROOT + "__menu"} icon={icon}
-          dropAlign={{right: 'right'}} a11yTitle={a11yTitle}
-          direction="column" closeOnClick={false}>
-          <Box direction={direction}
-            pad={{horizontal: 'large', vertical: 'medium', between: 'medium'}}
-            className={classNames.join(' ')}>
-            {filters}
-            {sort}
-          </Box>
-        </Menu>
+        <Box direction={direction}
+          pad={{horizontal: 'large', vertical: 'medium', between: 'medium'}}
+          className={classNames.join(' ')}>
+          {filters}
+          {sort}
+        </Box>
       );
     }
 

--- a/src/js/components/Filters.js
+++ b/src/js/components/Filters.js
@@ -93,7 +93,7 @@ export default class Filters extends Component {
       classNames.push(`${CLASS_ROOT}__drop`);
       result = (
         <Box direction={direction}
-          pad={{horizontal: 'large', vertical: 'medium', between: 'medium'}}
+          pad={{horizontal: 'large', between: 'medium'}}
           className={classNames.join(' ')}>
           {filters}
           {sort}

--- a/src/js/components/Filters.js
+++ b/src/js/components/Filters.js
@@ -81,9 +81,12 @@ export default class Filters extends Component {
 
   _renderIcon() {
     const { values } = this.props;
-    const selectedFilterCount = Object.keys(values).length;
+    const hasSelectedFilters = Object.keys(values).reduce((acc, key) => {
+      return values[key].length > 0;
+    }, false);
+
     return (
-      <FilterIcon colorIndex={selectedFilterCount ? 'brand' : undefined} />
+      <FilterIcon colorIndex={hasSelectedFilters ? 'brand' : undefined} />
     );
   }
 

--- a/src/js/components/Filters.js
+++ b/src/js/components/Filters.js
@@ -83,7 +83,7 @@ export default class Filters extends Component {
     const { values } = this.props;
     const selectedFilterCount = Object.keys(values).length;
     return (
-      <FilterIcon size="large" colorIndex={selectedFilterCount ? 'brand' : undefined} />
+      <FilterIcon colorIndex={selectedFilterCount ? 'brand' : undefined} />
     );
   }
 

--- a/src/js/components/Filters.js
+++ b/src/js/components/Filters.js
@@ -3,6 +3,7 @@
 import React, { Component, PropTypes } from 'react';
 import Menu from 'grommet/components/Menu';
 import Box from 'grommet/components/Box';
+import Sidebar from 'grommet/components/Sidebar';
 import FilterIcon from 'grommet/components/icons/base/Filter';
 import Filter from './Filter';
 import Sort from './Sort';
@@ -56,8 +57,49 @@ export default class Filters extends Component {
     return result;
   }
 
+  renderMenu ({ filters, sort, classNames }) {
+    const { values, direction } = this.props;
+
+    let a11yTitle = Intl.getMessage(this.context.intl, 'Filter');
+    const selectedFilterCount = Object.keys(values).length;
+    const icon = (
+      <FilterIcon colorIndex={selectedFilterCount ? 'brand' : undefined} />
+    );
+    return (
+      <div>
+        <Menu className={CLASS_ROOT + "__menu"} icon={icon}
+          dropAlign={{right: 'right'}} a11yTitle={a11yTitle}
+          direction="column" closeOnClick={false}>
+          <Box direction={direction}
+            pad={{horizontal: 'large', vertical: 'medium', between: 'medium'}}
+            className={classNames.join(' ')}>
+            {filters}
+            {sort}
+          </Box>
+        </Menu>
+        {this.props.filterCounts}
+      </div>
+    );
+  }
+
+  renderSidebar ({ filters, sort, classNames }) {
+    const { direction } = this.props;
+    return (
+      <Sidebar colorIndex="light-2">
+      {this.props.headingComponent}
+        <Box
+          direction={direction}
+          pad={{horizontal: 'large', vertical: 'medium', between: 'medium'}}
+          className={classNames.join(' ')}>
+          {filters}
+          {sort}
+        </Box>
+      </Sidebar>
+    );
+  }
+
   render () {
-    const { attributes, direction, inline, values } = this.props;
+    const { attributes, inline } = this.props;
     let classNames = [CLASS_ROOT];
     if (inline) {
       classNames.push(`${CLASS_ROOT}--inline`);
@@ -75,30 +117,12 @@ export default class Filters extends Component {
       sort = this._renderSort();
     }
 
-    const selectedFilterCount = Object.keys(values).length;
-    const icon = (
-      <FilterIcon colorIndex={selectedFilterCount ? 'brand' : undefined} />
-    );
-
     let result;
+
     if (inline) {
-      result = (
-        <Box direction={direction} pad={{between: 'medium'}}
-          className={classNames.join(' ')}>
-          {filters}
-          {sort}
-        </Box>
-      );
+      result = this.renderSidebar({filters, sort, classNames});
     } else {
-      classNames.push(`${CLASS_ROOT}__drop`);
-      result = (
-        <Box direction={direction}
-          pad={{horizontal: 'large', between: 'medium'}}
-          className={classNames.join(' ')}>
-          {filters}
-          {sort}
-        </Box>
-      );
+      result = this.renderMenu({filters, sort, classNames});
     }
 
     return result;

--- a/src/js/components/Header.js
+++ b/src/js/components/Header.js
@@ -11,6 +11,7 @@ import IndexPropTypes from '../utils/PropTypes';
 import IndexQuery from '../utils/Query';
 import Intl from 'grommet/utils/Intl';
 import Menu from 'grommet/components/Menu';
+import Button from 'grommet/components/Button';
 import FilterIcon from 'grommet/components/icons/base/Filter';
 
 const CLASS_ROOT = 'index-header';
@@ -47,9 +48,6 @@ export default class IndexHeader extends Component {
     const data = this.props.data || {};
 
     const classes = classnames(CLASS_ROOT, this.props.className);
-    const countClasses = classnames(`${CLASS_ROOT}__count`, {
-      [`${CLASS_ROOT}__count--active`]: data.unfilteredTotal > data.total
-    });
 
     const filterOrSortAttributes = attributes.filter(a => a.filter || a.sort);
     const selectedFilterCount = Object.keys(this.props.filter).length;
@@ -60,25 +58,28 @@ export default class IndexHeader extends Component {
 
     let filters;
     if (filterOrSortAttributes.length > 0) {
-      filters = (
-        <div className={`${CLASS_ROOT}__filters no-flex`}>
-          <Menu className={CLASS_ROOT + "__menu"} icon={icon}
-            dropAlign={{right: 'right'}} a11yTitle={a11yTitle}
-            direction="column" closeOnClick={false}>
-            <Filters attributes={filterOrSortAttributes}
-              direction={this.props.filterDirection}
-              values={this.props.filter} sort={this.props.sort}
-              onChange={this.props.onFilter}
-              onSort={this.props.onSort} />
-          </Menu>
-          <span className={`${CLASS_ROOT}__total`}>
-            {data.unfilteredTotal}
-          </span>
-          <span className={countClasses}>
-            {data.total}
-          </span>
-        </div>
+      filters = !this.props.inlineFilterOpen && (
+        <Button plain={true} onClick={this.props.toggleInlineFilter}>
+          <FilterIcon />
+        </Button>
       );
+
+      if (this.props.filterType === 'menu') {
+        filters = (
+          <div className={`${CLASS_ROOT}__filters no-flex`}>
+            <Menu className={CLASS_ROOT + "__menu"} icon={icon}
+              dropAlign={{right: 'right'}} a11yTitle={a11yTitle}
+              direction="column" closeOnClick={false}>
+              <Filters attributes={filterOrSortAttributes}
+                direction={this.props.filterDirection}
+                values={this.props.filter} sort={this.props.sort}
+                onChange={this.props.onFilter}
+                onSort={this.props.onSort} />
+            </Menu>
+            {this.props.filterCounts}
+          </div>
+        );
+      }
     }
 
     const placeHolder = Intl.getMessage(this.context.intl, 'Search');

--- a/src/js/components/Header.js
+++ b/src/js/components/Header.js
@@ -44,29 +44,11 @@ export default class IndexHeader extends Component {
   }
 
   render () {
-    const { attributes, filterControl } = this.props;
-    const data = this.props.data || {};
+    const { attributes } = this.props;
 
     const classes = classnames(CLASS_ROOT, this.props.className);
-    const countClasses = classnames(`${CLASS_ROOT}__count`, {
-      [`${CLASS_ROOT}__count--active`]: data.unfilteredTotal > data.total
-    });
 
     const filterOrSortAttributes = attributes.filter(a => a.filter || a.sort);
-    let filters;
-    if (filterOrSortAttributes.length > 0 && filterControl) {
-      filters = (
-        <div className={`${CLASS_ROOT}__filters no-flex`}>
-          {filterControl}
-          <span className={`${CLASS_ROOT}__total`}>
-            {data.unfilteredTotal}
-          </span>
-          <span className={countClasses}>
-            {data.total}
-          </span>
-        </div>
-      );
-    }
 
     const placeHolder = Intl.getMessage(this.context.intl, 'Search');
 
@@ -84,7 +66,7 @@ export default class IndexHeader extends Component {
             value={this.state.value}
             onDOMChange={this._onChangeSearch} />
           {this.props.addControl}
-          {this.props.filterControl}
+          {filterOrSortAttributes.length > 0 && this.props.filterControl}
         </Box>
       </Header>
     );

--- a/src/js/components/Header.js
+++ b/src/js/components/Header.js
@@ -10,6 +10,8 @@ import Filters from './Filters';
 import IndexPropTypes from '../utils/PropTypes';
 import IndexQuery from '../utils/Query';
 import Intl from 'grommet/utils/Intl';
+import Menu from 'grommet/components/Menu';
+import FilterIcon from 'grommet/components/icons/base/Filter';
 
 const CLASS_ROOT = 'index-header';
 
@@ -50,16 +52,25 @@ export default class IndexHeader extends Component {
     });
 
     const filterOrSortAttributes = attributes.filter(a => a.filter || a.sort);
+    const selectedFilterCount = Object.keys(this.props.filter).length;
+    const icon = (
+      <FilterIcon colorIndex={selectedFilterCount ? 'brand' : undefined} />
+    );
+    let a11yTitle = Intl.getMessage(this.context.intl, 'Filter');
 
     let filters;
     if (filterOrSortAttributes.length > 0) {
       filters = (
         <div className={`${CLASS_ROOT}__filters no-flex`}>
-          <Filters attributes={filterOrSortAttributes}
-            direction={this.props.filterDirection}
-            values={this.props.filter} sort={this.props.sort}
-            onChange={this.props.onFilter}
-            onSort={this.props.onSort} />
+          <Menu className={CLASS_ROOT + "__menu"} icon={icon}
+            dropAlign={{right: 'right'}} a11yTitle={a11yTitle}
+            direction="column" closeOnClick={false}>
+            <Filters attributes={filterOrSortAttributes}
+              direction={this.props.filterDirection}
+              values={this.props.filter} sort={this.props.sort}
+              onChange={this.props.onFilter}
+              onSort={this.props.onSort} />
+          </Menu>
           <span className={`${CLASS_ROOT}__total`}>
             {data.unfilteredTotal}
           </span>

--- a/src/js/components/Header.js
+++ b/src/js/components/Header.js
@@ -44,42 +44,28 @@ export default class IndexHeader extends Component {
   }
 
   render () {
-    const { attributes } = this.props;
+    const { attributes, filterControl } = this.props;
     const data = this.props.data || {};
 
     const classes = classnames(CLASS_ROOT, this.props.className);
+    const countClasses = classnames(`${CLASS_ROOT}__count`, {
+      [`${CLASS_ROOT}__count--active`]: data.unfilteredTotal > data.total
+    });
 
     const filterOrSortAttributes = attributes.filter(a => a.filter || a.sort);
-    const selectedFilterCount = Object.keys(this.props.filter).length;
-    const icon = (
-      <FilterIcon colorIndex={selectedFilterCount ? 'brand' : undefined} />
-    );
-    let a11yTitle = Intl.getMessage(this.context.intl, 'Filter');
-
     let filters;
-    if (filterOrSortAttributes.length > 0) {
-      filters = !this.props.inlineFilterOpen && (
-        <Button plain={true} onClick={this.props.toggleInlineFilter}>
-          <FilterIcon />
-        </Button>
+    if (filterOrSortAttributes.length > 0 && filterControl) {
+      filters = (
+        <div className={`${CLASS_ROOT}__filters no-flex`}>
+          {filterControl}
+          <span className={`${CLASS_ROOT}__total`}>
+            {data.unfilteredTotal}
+          </span>
+          <span className={countClasses}>
+            {data.total}
+          </span>
+        </div>
       );
-
-      if (this.props.filterType === 'menu') {
-        filters = (
-          <div className={`${CLASS_ROOT}__filters no-flex`}>
-            <Menu className={CLASS_ROOT + "__menu"} icon={icon}
-              dropAlign={{right: 'right'}} a11yTitle={a11yTitle}
-              direction="column" closeOnClick={false}>
-              <Filters attributes={filterOrSortAttributes}
-                direction={this.props.filterDirection}
-                values={this.props.filter} sort={this.props.sort}
-                onChange={this.props.onFilter}
-                onSort={this.props.onSort} />
-            </Menu>
-            {this.props.filterCounts}
-          </div>
-        );
-      }
     }
 
     const placeHolder = Intl.getMessage(this.context.intl, 'Search');
@@ -97,8 +83,8 @@ export default class IndexHeader extends Component {
             placeHolder={placeHolder}
             value={this.state.value}
             onDOMChange={this._onChangeSearch} />
-          {filters}
           {this.props.addControl}
+          {this.props.filterControl}
         </Box>
       </Header>
     );

--- a/src/js/components/Header.js
+++ b/src/js/components/Header.js
@@ -6,13 +6,9 @@ import classnames from 'classnames';
 import Header from 'grommet/components/Header';
 import Search from 'grommet/components/Search';
 import Box from 'grommet/components/Box';
-import Filters from './Filters';
 import IndexPropTypes from '../utils/PropTypes';
 import IndexQuery from '../utils/Query';
 import Intl from 'grommet/utils/Intl';
-import Menu from 'grommet/components/Menu';
-import Button from 'grommet/components/Button';
-import FilterIcon from 'grommet/components/icons/base/Filter';
 
 const CLASS_ROOT = 'index-header';
 

--- a/src/js/components/Index.js
+++ b/src/js/components/Index.js
@@ -48,7 +48,6 @@ export default class Index extends Component {
   }
 
   _toggleInlineFilter() {
-    console.log(this);
     this.setState({
       inlineFilterOpen: !this.state.inlineFilterOpen
     });
@@ -126,6 +125,43 @@ export default class Index extends Component {
         {data.total}
       </span>
     ];
+
+    let filterControl;
+    let filterHeading;
+    const { filtersInline } = this.props;
+    const { inlineFilterOpen } = this.state;
+
+    if (filtersInline) {
+      filterHeading = (
+        <Header size="large" pad={{horizontal: 'medium'}} justify="between">
+          {Intl.getMessage(this.context.intl, 'Filter by')}
+          <div className={`${CLASS_ROOT}__filters no-flex`}>
+            <Button plain={true} onClick={this._toggleInlineFilter}>
+              <FilterIcon onClick={this._toggleInlineFilter}/>
+              {filterCounts}
+            </Button>
+          </div>
+        </Header>
+      );
+      if (!inlineFilterOpen) {
+        filterControl = (
+          <Button plain={true} onClick={this._toggleInlineFilter}>
+            <FilterIcon/>
+          </Button>
+        );
+      }
+    } else {
+      filterControl = (
+        <div className={`${CLASS_ROOT}__filters no-flex`}>
+          <Filters
+            attributes={this.props.attributes}
+            data={data}
+            sort={this.props.sort}
+            filterCounts={filterCounts}/>
+        </div>
+      );
+    }
+
     return (
       <div className={classes.join(' ')}>
         <div className={`${CLASS_ROOT}__container`}>
@@ -144,8 +180,7 @@ export default class Index extends Component {
                 addControl={this.props.addControl}
                 navControl={this.props.navControl}
                 filterCounts={filterCounts}
-                toggleInlineFilter={this._toggleInlineFilter}
-                inlineFilterOpen={this.state.inlineFilterOpen} />
+                filterControl={filterControl} />
               {error}
               {notifications}
               <div ref="items" className={`${CLASS_ROOT}__items`}>
@@ -165,22 +200,13 @@ export default class Index extends Component {
                 {empty}
               </div>
             </div>
-            {this.state.inlineFilterOpen &&
-              <Sidebar colorIndex="light-2">
-                <Header size="large" pad={{horizontal: 'medium'}} justify="between">
-                  Filter By
-                  <div className={`index-header__filters no-flex`}>
-                    <Button plain={true} onClick={this._toggleInlineFilter}>
-                      <FilterIcon onClick={this._toggleInlineFilter}/>
-                      {filterCounts}
-                    </Button>
-                  </div>
-                </Header>
-                <Filters
-                  attributes={this.props.attributes}
-                  data={data}
-                  sort={this.props.sort}/>
-              </Sidebar>
+            {filtersInline && inlineFilterOpen &&
+              <Filters
+                headingComponent={filterHeading}
+                inline={true}
+                attributes={this.props.attributes}
+                data={data}
+                sort={this.props.sort}/>
             }
           </Split>
         </div>

--- a/src/js/components/Index.js
+++ b/src/js/components/Index.js
@@ -112,8 +112,11 @@ export default class Index extends Component {
     const ViewComponent = VIEW_COMPONENT[view];
 
     let filterControl;
-    const { filtersInline } = this.props;
+    let { filtersInline } = this.props;
     const { inlineFilterOpen } = this.state;
+
+    // mobile view doesn't get inline filter
+    filtersInline = filtersInline && window.innerWidth >= Responsive.smallSize();
 
     if (filtersInline && !inlineFilterOpen) {
       // only show the filterControl if the sidebar is closed

--- a/src/js/components/Index.js
+++ b/src/js/components/Index.js
@@ -1,10 +1,8 @@
 // (C) Copyright 2014-2015 Hewlett Packard Enterprise Development LP
 
 import React, { Component, PropTypes } from 'react';
-import classnames from 'classnames';
 import Box from 'grommet/components/Box';
 import Split from 'grommet/components/Split';
-import Header from 'grommet/components/Header';
 import Button from 'grommet/components/Button';
 import FilterIcon from 'grommet/components/icons/base/Filter';
 import Responsive from 'grommet/utils/Responsive';
@@ -113,52 +111,28 @@ export default class Index extends Component {
     }
     const ViewComponent = VIEW_COMPONENT[view];
 
-    const countClasses = classnames(`${CLASS_ROOT}__count`, {
-      [`${CLASS_ROOT}__count--active`]: data.unfilteredTotal > data.total
-    });
-
-    const filterCounts = [
-      <span className={`${CLASS_ROOT}__total`}>
-        {data.unfilteredTotal}
-      </span>,
-      <span className={countClasses}>
-        {data.total}
-      </span>
-    ];
-
     let filterControl;
-    let filterHeading;
     const { filtersInline } = this.props;
     const { inlineFilterOpen } = this.state;
 
-    if (filtersInline) {
-      filterHeading = (
-        <Header size="large" pad={{horizontal: 'medium'}} justify="between">
-          {Intl.getMessage(this.context.intl, 'Filter by')}
-          <div className={`${CLASS_ROOT}__filters no-flex`}>
-            <Button plain={true} onClick={this._toggleInlineFilter}>
-              <FilterIcon onClick={this._toggleInlineFilter}/>
-              {filterCounts}
-            </Button>
-          </div>
-        </Header>
-      );
-      if (!inlineFilterOpen) {
-        filterControl = (
-          <Button plain={true} onClick={this._toggleInlineFilter}>
-            <FilterIcon/>
-          </Button>
-        );
-      }
-    } else {
+    if (filtersInline && !inlineFilterOpen) {
+      // only show the filterControl if the sidebar is closed
+      const selectedFilterCount = Object.keys(this.props.filter).length;
       filterControl = (
-        <div className={`${CLASS_ROOT}__filters no-flex`}>
-          <Filters
-            attributes={this.props.attributes}
-            data={data}
-            sort={this.props.sort}
-            filterCounts={filterCounts}/>
-        </div>
+        <Button
+          icon={<FilterIcon colorIndex={selectedFilterCount ? 'brand' : undefined}/>}
+          plain={true}
+          onClick={this._toggleInlineFilter} />
+      );
+    } else if (!filtersInline) {
+      filterControl = (
+        <Filters
+          attributes={this.props.attributes}
+          data={data}
+          values={this.props.filter}
+          sort={this.props.sort}
+          onChange={this.props.onFilter}
+          onSort={this.props.onSort} />
       );
     }
 
@@ -179,7 +153,6 @@ export default class Index extends Component {
                 fixed={this.props.fixed}
                 addControl={this.props.addControl}
                 navControl={this.props.navControl}
-                filterCounts={filterCounts}
                 filterControl={filterControl} />
               {error}
               {notifications}
@@ -202,11 +175,14 @@ export default class Index extends Component {
             </div>
             {filtersInline && inlineFilterOpen &&
               <Filters
-                headingComponent={filterHeading}
                 inline={true}
                 attributes={this.props.attributes}
                 data={data}
-                sort={this.props.sort}/>
+                values={this.props.filter}
+                sort={this.props.sort}
+                onClose={this._toggleInlineFilter}
+                onChange={this.props.onFilter}
+                onSort={this.props.onSort}/>
             }
           </Split>
         </div>

--- a/src/js/components/Index.js
+++ b/src/js/components/Index.js
@@ -3,19 +3,19 @@
 import React, { Component, PropTypes } from 'react';
 import classnames from 'classnames';
 import Box from 'grommet/components/Box';
+import Split from 'grommet/components/Split';
+import Header from 'grommet/components/Header';
+import Button from 'grommet/components/Button';
+import FilterIcon from 'grommet/components/icons/base/Filter';
 import Responsive from 'grommet/utils/Responsive';
+
 import IndexPropTypes from '../utils/PropTypes';
 import IndexTable from './Table';
 import IndexTiles from './Tiles';
 import IndexList from './List';
 import IndexHeader from './Header';
-import Intl from 'grommet/utils/Intl';
-import Split from 'grommet/components/Split';
-import Sidebar from 'grommet/components/Sidebar';
 import Filters from './Filters';
-import Header from 'grommet/components/Header';
-import Button from 'grommet/components/Button';
-import FilterIcon from 'grommet/components/icons/base/Filter';
+import Intl from 'grommet/utils/Intl';
 
 const CLASS_ROOT = 'index';
 
@@ -31,7 +31,7 @@ export default class Index extends Component {
     super();
     this._onResponsive = this._onResponsive.bind(this);
     this._toggleInlineFilter = this._toggleInlineFilter.bind(this);
-    this.state = { responsiveSize: 'medium', inlineFilterOpen: true };
+    this.state = { responsiveSize: 'medium' };
 
   }
 

--- a/src/js/components/Index.js
+++ b/src/js/components/Index.js
@@ -1,6 +1,7 @@
 // (C) Copyright 2014-2015 Hewlett Packard Enterprise Development LP
 
 import React, { Component, PropTypes } from 'react';
+import classnames from 'classnames';
 import Box from 'grommet/components/Box';
 import Responsive from 'grommet/utils/Responsive';
 import IndexPropTypes from '../utils/PropTypes';
@@ -12,7 +13,9 @@ import Intl from 'grommet/utils/Intl';
 import Split from 'grommet/components/Split';
 import Sidebar from 'grommet/components/Sidebar';
 import Filters from './Filters';
-import classnames from 'classnames';
+import Header from 'grommet/components/Header';
+import Button from 'grommet/components/Button';
+import FilterIcon from 'grommet/components/icons/base/Filter';
 
 const CLASS_ROOT = 'index';
 
@@ -27,7 +30,9 @@ export default class Index extends Component {
   constructor () {
     super();
     this._onResponsive = this._onResponsive.bind(this);
-    this.state = { responsiveSize: 'medium' };
+    this._toggleInlineFilter = this._toggleInlineFilter.bind(this);
+    this.state = { responsiveSize: 'medium', inlineFilterOpen: true };
+
   }
 
   componentDidMount () {
@@ -40,6 +45,13 @@ export default class Index extends Component {
 
   _onResponsive (small) {
     this.setState({ responsiveSize: (small ? 'small' : 'medium') });
+  }
+
+  _toggleInlineFilter() {
+    console.log(this);
+    this.setState({
+      inlineFilterOpen: !this.state.inlineFilterOpen
+    });
   }
 
   render () {
@@ -105,26 +117,15 @@ export default class Index extends Component {
     const countClasses = classnames(`${CLASS_ROOT}__count`, {
       [`${CLASS_ROOT}__count--active`]: data.unfilteredTotal > data.total
     });
-    const filterOrSortAttributes = this.props.attributes.filter(a => a.filter || a.sort);
 
-    let filters;
-    if (filterOrSortAttributes.length > 0) {
-      filters = (
-        <div className={`${CLASS_ROOT}__filters no-flex`}>
-          <Filters attributes={filterOrSortAttributes}
-            direction={this.props.filterDirection}
-            values={this.props.filter} sort={this.props.sort}
-            onChange={this.props.onFilter}
-            onSort={this.props.onSort} />
-          <span className={`${CLASS_ROOT}__total`}>
-            {data.unfilteredTotal}
-          </span>
-          <span className={countClasses}>
-            {data.total}
-          </span>
-        </div>
-      );
-    }
+    const filterCounts = [
+      <span className={`${CLASS_ROOT}__total`}>
+        {data.unfilteredTotal}
+      </span>,
+      <span className={countClasses}>
+        {data.total}
+      </span>
+    ];
     return (
       <div className={classes.join(' ')}>
         <div className={`${CLASS_ROOT}__container`}>
@@ -133,6 +134,7 @@ export default class Index extends Component {
               <IndexHeader className={`${CLASS_ROOT}__header`}
                 label={this.props.label}
                 attributes={this.props.attributes}
+                filterType={this.props.filterType}
                 filterDirection={this.props.filterDirection}
                 filter={this.props.filter} onFilter={this.props.onFilter}
                 query={this.props.query} onQuery={this.props.onQuery}
@@ -140,7 +142,10 @@ export default class Index extends Component {
                 data={data}
                 fixed={this.props.fixed}
                 addControl={this.props.addControl}
-                navControl={this.props.navControl} />
+                navControl={this.props.navControl}
+                filterCounts={filterCounts}
+                toggleInlineFilter={this._toggleInlineFilter}
+                inlineFilterOpen={this.state.inlineFilterOpen} />
               {error}
               {notifications}
               <div ref="items" className={`${CLASS_ROOT}__items`}>
@@ -160,12 +165,23 @@ export default class Index extends Component {
                 {empty}
               </div>
             </div>
-            <Sidebar colorIndex="light-2">
-              <Filters
-                attributes={this.props.attributes}
-                data={data}
-                sort={this.props.sort}/>
-            </Sidebar>
+            {this.state.inlineFilterOpen &&
+              <Sidebar colorIndex="light-2">
+                <Header size="large" pad={{horizontal: 'medium'}} justify="between">
+                  Filter By
+                  <div className={`index-header__filters no-flex`}>
+                    <Button plain={true} onClick={this._toggleInlineFilter}>
+                      <FilterIcon onClick={this._toggleInlineFilter}/>
+                      {filterCounts}
+                    </Button>
+                  </div>
+                </Header>
+                <Filters
+                  attributes={this.props.attributes}
+                  data={data}
+                  sort={this.props.sort}/>
+              </Sidebar>
+            }
           </Split>
         </div>
       </div>

--- a/src/js/components/Index.js
+++ b/src/js/components/Index.js
@@ -116,7 +116,7 @@ export default class Index extends Component {
     const { inlineFilterOpen } = this.state;
 
     // mobile view doesn't get inline filter
-    filtersInline = filtersInline && window.innerWidth >= Responsive.smallSize();
+    filtersInline = filtersInline && this.state.responsiveSize !== 'small';
 
     if (filtersInline && !inlineFilterOpen) {
       // only show the filterControl if the sidebar is closed

--- a/src/js/components/Index.js
+++ b/src/js/components/Index.js
@@ -9,6 +9,10 @@ import IndexTiles from './Tiles';
 import IndexList from './List';
 import IndexHeader from './Header';
 import Intl from 'grommet/utils/Intl';
+import Split from 'grommet/components/Split';
+import Sidebar from 'grommet/components/Sidebar';
+import Filters from './Filters';
+import classnames from 'classnames';
 
 const CLASS_ROOT = 'index';
 
@@ -98,38 +102,71 @@ export default class Index extends Component {
     }
     const ViewComponent = VIEW_COMPONENT[view];
 
+    const countClasses = classnames(`${CLASS_ROOT}__count`, {
+      [`${CLASS_ROOT}__count--active`]: data.unfilteredTotal > data.total
+    });
+    const filterOrSortAttributes = this.props.attributes.filter(a => a.filter || a.sort);
+
+    let filters;
+    if (filterOrSortAttributes.length > 0) {
+      filters = (
+        <div className={`${CLASS_ROOT}__filters no-flex`}>
+          <Filters attributes={filterOrSortAttributes}
+            direction={this.props.filterDirection}
+            values={this.props.filter} sort={this.props.sort}
+            onChange={this.props.onFilter}
+            onSort={this.props.onSort} />
+          <span className={`${CLASS_ROOT}__total`}>
+            {data.unfilteredTotal}
+          </span>
+          <span className={countClasses}>
+            {data.total}
+          </span>
+        </div>
+      );
+    }
     return (
       <div className={classes.join(' ')}>
         <div className={`${CLASS_ROOT}__container`}>
-          <IndexHeader className={`${CLASS_ROOT}__header`}
-            label={this.props.label}
-            attributes={this.props.attributes}
-            filterDirection={this.props.filterDirection}
-            filter={this.props.filter} onFilter={this.props.onFilter}
-            query={this.props.query} onQuery={this.props.onQuery}
-            sort={this.props.sort} onSort={this.props.onSort}
-            data={data}
-            fixed={this.props.fixed}
-            addControl={this.props.addControl}
-            navControl={this.props.navControl} />
-          {error}
-          {notifications}
-          <div ref="items" className={`${CLASS_ROOT}__items`}>
-            <ViewComponent
-              actions={this.props.actions}
-              attributes={this.props.attributes}
-              fill={this.props.fill}
-              flush={this.props.flush}
-              itemComponent={itemComponent}
-              data={data}
-              sections={this.props.sections}
-              selection={this.props.selection}
-              size={this.props.size}
-              sort={this.props.sort}
-              onSelect={this.props.onSelect}
-              onMore={this.props.onMore} />
-            {empty}
-          </div>
+          <Split flex="left" priority="left" fixed={true}>
+            <div>
+              <IndexHeader className={`${CLASS_ROOT}__header`}
+                label={this.props.label}
+                attributes={this.props.attributes}
+                filterDirection={this.props.filterDirection}
+                filter={this.props.filter} onFilter={this.props.onFilter}
+                query={this.props.query} onQuery={this.props.onQuery}
+                sort={this.props.sort} onSort={this.props.onSort}
+                data={data}
+                fixed={this.props.fixed}
+                addControl={this.props.addControl}
+                navControl={this.props.navControl} />
+              {error}
+              {notifications}
+              <div ref="items" className={`${CLASS_ROOT}__items`}>
+                <ViewComponent
+                  actions={this.props.actions}
+                  attributes={this.props.attributes}
+                  fill={this.props.fill}
+                  flush={this.props.flush}
+                  itemComponent={itemComponent}
+                  data={data}
+                  sections={this.props.sections}
+                  selection={this.props.selection}
+                  size={this.props.size}
+                  sort={this.props.sort}
+                  onSelect={this.props.onSelect}
+                  onMore={this.props.onMore} />
+                {empty}
+              </div>
+            </div>
+            <Sidebar colorIndex="light-2">
+              <Filters
+                attributes={this.props.attributes}
+                data={data}
+                sort={this.props.sort}/>
+            </Sidebar>
+          </Split>
         </div>
       </div>
     );

--- a/src/js/messages/en-US.js
+++ b/src/js/messages/en-US.js
@@ -3,5 +3,6 @@
 export default {
   'No matches': 'No matches',
   Sort: 'Sort',
-  FilterSummary: '{count, number} values'
+  FilterSummary: '{count, number} values',
+  'Filter by': 'Filter by'
 };

--- a/src/scss/grommet-index/_objects.index-filters.scss
+++ b/src/scss/grommet-index/_objects.index-filters.scss
@@ -2,4 +2,6 @@
 
 .index-filters {
   border: 0px;
+
+  @include filter-counts();
 }

--- a/src/scss/grommet-index/_objects.index-header.scss
+++ b/src/scss/grommet-index/_objects.index-header.scss
@@ -1,33 +1,11 @@
 // (C) Copyright 2014-2016 Hewlett Packard Enterprise Development LP
 
-.index-header__controls {
-  // This is for IE11.
-  // https://connect.microsoft.com/IE/feedback/details/816293/ie11-flexbox-with-min-height-not-vertically-aligning-with-align-items-center
-  height: $large-header-height;
-}
-
-.index-header__filters {
-  position: relative; // for total and count below
-}
-
-.index-header__total,
-.index-header__count {
-  @include media-query(palm) {
-    display: none;
+.index-header {
+  &__controls {
+    // This is for IE11.
+    // https://connect.microsoft.com/IE/feedback/details/816293/ie11-flexbox-with-min-height-not-vertically-aligning-with-align-items-center
+    height: $large-header-height;
   }
 
-  @include media-query(lap-and-up) {
-    position: absolute;
-    left: $inuit-base-spacing-unit;
-    transform: translateX(-50%);
-    color: $secondary-text-color;
-    text-align: center;
-    @include inuit-font-size($label-font-size);
-  }
-}
-
-.index-header__total {
-  @include media-query(lap-and-up) {
-    top: - halve($inuit-base-spacing-unit);
-  }
+  @include filter-counts();
 }

--- a/src/scss/grommet-index/_objects.index-header.scss
+++ b/src/scss/grommet-index/_objects.index-header.scss
@@ -31,15 +31,3 @@
     top: - halve($inuit-base-spacing-unit);
   }
 }
-
-.index-header__count {
-  display: none;
-
-  @include media-query(lap-and-up) {
-    &.index-header__count--active {
-      display: block;
-      position: absolute;
-      bottom: - halve($inuit-base-spacing-unit);
-    }
-  }
-}

--- a/src/scss/grommet-index/_objects.index.scss
+++ b/src/scss/grommet-index/_objects.index.scss
@@ -22,4 +22,43 @@
     color: map-get($brand-status-colors, error);
     border-bottom: 1px solid $border-color;
   }
+
+  &__total,
+  &__count {
+    @include media-query(palm) {
+      display: none;
+    }
+
+    @include media-query(lap-and-up) {
+      position: absolute;
+      left: $inuit-base-spacing-unit;
+      transform: translateX(-50%);
+      color: $secondary-text-color;
+      text-align: center;
+      @include inuit-font-size($label-font-size);
+    }
+  }
+
+  &__total {
+    @include media-query(lap-and-up) {
+      top: - halve($inuit-base-spacing-unit);
+    }
+  }
+
+  &__count {
+    display: none;
+
+    @include media-query(lap-and-up) {
+      &--active {
+        display: block;
+        position: absolute;
+        bottom: - halve($inuit-base-spacing-unit);
+      }
+    }
+  }
 }
+
+.index__count {
+    @include inuit-font-size($label-font-size);
+}
+

--- a/src/scss/grommet-index/_objects.index.scss
+++ b/src/scss/grommet-index/_objects.index.scss
@@ -62,5 +62,7 @@
     color: map-get($brand-status-colors, error);
     border-bottom: 1px solid $border-color;
   }
+
+  @include filter-counts();
 }
 

--- a/src/scss/grommet-index/_objects.index.scss
+++ b/src/scss/grommet-index/_objects.index.scss
@@ -1,26 +1,8 @@
 // (C) Copyright 2014-2015 Hewlett Packard Enterprise Development LP
 
-.index {
-  max-width: 100%;
-  overflow: auto;
-
-  &__container {
+@mixin filter-counts {
+  &__filters {
     position: relative;
-  }
-
-  &__items {
-    position: relative;
-    width: 100%;
-  }
-
-  &__more {
-    padding-top: $inuit-base-spacing-unit;
-  }
-
-  &__error {
-    padding: quarter($inuit-base-spacing-unit) $inuit-base-spacing-unit;
-    color: map-get($brand-status-colors, error);
-    border-bottom: 1px solid $border-color;
   }
 
   &__total,
@@ -58,7 +40,27 @@
   }
 }
 
-.index__count {
-    @include inuit-font-size($label-font-size);
+.index {
+  max-width: 100%;
+  overflow: auto;
+
+  &__container {
+    position: relative;
+  }
+
+  &__items {
+    position: relative;
+    width: 100%;
+  }
+
+  &__more {
+    padding-top: $inuit-base-spacing-unit;
+  }
+
+  &__error {
+    padding: quarter($inuit-base-spacing-unit) $inuit-base-spacing-unit;
+    color: map-get($brand-status-colors, error);
+    border-bottom: 1px solid $border-color;
+  }
 }
 


### PR DESCRIPTION
Adds a new prop to `Index` to support inline filters. `<Index filtersInline={true} ... />` will convert the filters from a `Menu` component to a `Sidebar` component rendered inside a `Split`.  This gives the user the ability to have the filters visible at all times while interacting with the page. 

At narrow widths, inline filters is disabled and the `Menu` component is used.

If no filter or sort properties are set in the `attributes` prop, the filters will not display, regardless of the value of `filtersInline`

Codepen demonstration:  http://codepen.io/nickjvm/pen/LkaRZA?editors=0010
