### PR TITLE
Utilize responsive util to show/hide preamble node

### DIFF
--- a/src/js/components/Index.js
+++ b/src/js/components/Index.js
@@ -162,6 +162,10 @@ export default class Index extends Component {
           onSort={this.props.onSort} />
       );
     }
+    let preamble;
+    if (this.props.preamble && this.state.responsiveSize !== 'small') {
+      preamble = this.props.preamble;
+    }
 
     return (
       <div className={classes.join(' ')}>
@@ -181,6 +185,7 @@ export default class Index extends Component {
                 addControl={this.props.addControl}
                 navControl={this.props.navControl}
                 filterControl={filterControl} />
+              {preamble}
               {error}
               {notifications}
               <div ref="items" className={`${CLASS_ROOT}__items`}>
@@ -270,6 +275,7 @@ Index.propTypes = {
 Index.defaultProps = {
   attributes: [{name: 'name', label: 'Name', index: 0}],
   filterDirection: 'column',
+  preamble: PropTypes.node,
   fixed: true,
   flush: true,
   view: "tiles"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->
#### What does this PR do?

Gives the user the ability to render text, element, or notification of the sort underneath the `<IndexHeader/>`.
#### Where should the reviewer start?

Line `165`.
#### What testing has been done on this PR?

✅ Linting
✅ Manual 
#### How should this be manually tested?

Propagate a `string` or `element` through the `preamble` attr.
#### Any background context you want to provide?

Implementing a instructional walk through in current project, allowing subtext with links underneath headers.
#### What are the relevant issues?

Allowing a sub text underneath the search, this could be used as an instructional, or error message, or any type of notification of the sort.
#### Screenshots (if appropriate)
#### Do the grommet-index docs need to be updated?

👍 
#### Should this PR be mentioned in the release notes?

👍 
#### Is this change backwards compatible or is it a breaking change?

👍
