### PR TITLE
Added 'between' operator for nodes and case insensitive parsers

### DIFF
--- a/src/js/utils/Query.js
+++ b/src/js/utils/Query.js
@@ -3,15 +3,16 @@
 import StringConvert from 'grommet/utils/StringConvert';
 
 const TRACE_PARSING = false;
-// This pattern matches the name: ^[^\d='"\s]{2}[^='"\s]+
+// don't convert timestamps, MAC addresses, or WWNs to attribute:value
+// This pattern matches the name: ^[^\d:'"\s]{2}[^:'"\s]+
 // We allow for the value to be optionally be quoted. So, we repeat the name
 // pattern three times, once for single quoted value, once for double quoted
 // value, and lastly with no quotes.
 // We don't build this programmatically for better performance.
 const ATTRIBUTE_PATTERN = new RegExp([
-  `^[^\d='"\s]{1}[^='"\s]*='[^']+'`,
-  `^[^\d='"\s]{1}[^='"\s]*="[^"]+"`,
-  `^[^\d='"\s]{1}[^='"\s]*=[^'"\s]+`].join('|'));
+  `^[^\d:'"\s]{1}[^:'"\s]*:'[^']+'`,
+  `^[^\d:'"\s]{1}[^:'"\s]*:"[^"]+"`,
+  `^[^\d:'"\s]{1}[^:'"\s]*:[^'"\s]+`].join('|'));
 // allow for text to contain quotes
 const TEXT_PATTERN = /^[^'"\s]+|^'[^']+'|^"[^"]+"/;
 
@@ -129,9 +130,9 @@ function parseAttribute (text, expression) {
   const matches = text.match(ATTRIBUTE_PATTERN);
   if (matches) {
     traceParsing('--attribute--');
-    // attribute=value
+    // attribute:value
     result = matches[0].length;
-    const parts = matches[0].split('=');
+    const parts = matches[0].split(':');
     const term = {
       text: matches[0],
       name: parts[0],


### PR DESCRIPTION
#### What does this PR do?

Simple enhancements to utils/Query so it understands operator 'between' and node values can be lowercase.
#### Where should the reviewer start?

utils/Query
#### What testing has been done on this PR?

Is being used in our current project. Tests added on this branch: N/A.
#### How should this be manually tested?

Provide Query a simple text to parse. Include operator 'between'.
`new Query('(BETWEEN x y) AND (n:v OR n:w) "big deal" NOT 01:23:45:67:89:ab 2016-01-31T16:45:46Z');`
#### Any background context you want to provide?

Our current project uses Query. Operators like 'between' can be simply added to the parsers list. Other extra enhancements are just an improvement over small limitations, like parsing node values only on 
capital letters.
#### What are the relevant issues?

None yet.
#### Screenshots (if appropriate)

N/A.
#### Do the grommet-index docs need to be updated?

Absolutely necessary.
#### Should this PR be mentioned in the release notes?

Yes.
#### Is this change backwards compatible or is it a breaking change?

Yes - backwards compatible.
