### PR TITLE
Changed Tiles key value from label to i(index)

### DIFF
--- a/src/js/components/Tiles.js
+++ b/src/js/components/Tiles.js
@@ -125,7 +125,7 @@ export default class IndexTiles extends Component {
         if (tiles.length > 0) {
           // only use onMore for last section
           let content = (
-            <Tiles key={label}
+            <Tiles key={i}
               onMore={i === data.sections.length - 1 ? onMore : undefined}
               flush={this.props.flush} fill={this.props.fill}
               selectable={this.props.onSelect ? true : false}
@@ -135,7 +135,7 @@ export default class IndexTiles extends Component {
           );
 
           sections.push(
-            <div key={label} className={`${CLASS_ROOT}__section`}>
+            <div key={i} className={`${CLASS_ROOT}__section`}>
               <Header size="small" justify="between" responsive={false}
                 separator="top" pad={{horizontal: 'small'}}>
                 <label className="secondary">{label}</label>


### PR DESCRIPTION
Changed Tiles component 'key' value from 'label' to 'i' (index) because in some cases the label may be the same for multiple sections.

We need this change because we want to send a React Intl component as the section label, to group by date.

The change is encapsulated so it should not affect other components.
