### PR TITLE
Passed defaultValue to Search component from Index component

### DIFF
--- a/src/js/components/Header.js
+++ b/src/js/components/Header.js
@@ -66,6 +66,7 @@ export default class IndexHeader extends Component {
             placeHolder={placeHolder}
             value={this.state.value}
             onDOMChange={this._onChangeSearch}
+            defaultValue={this.props.defaultValue}
             suggestions={this.props.suggestions}
             onSelect={this.props.onSelect} />
           {this.props.addControl}
@@ -80,6 +81,7 @@ export default class IndexHeader extends Component {
 IndexHeader.propTypes = {
   addControl: PropTypes.node,
   attributes: IndexPropTypes.attributes.isRequired,
+  defaultValue: PropTypes.string,
   filter: PropTypes.object, // { name: [value, ...] }
   filterDirection: PropTypes.oneOf(['row', 'column']),
   fixed: PropTypes.bool,

--- a/src/js/components/Index.js
+++ b/src/js/components/Index.js
@@ -195,7 +195,8 @@ export default class Index extends Component {
                 navControl={this.props.navControl}
                 filterControl={filterControl}
                 suggestions={this.props.suggestions}
-                onSelect={this.props.onSuggestionSelect} />
+                onSelect={this.props.onSuggestionSelect}
+                defaultValue={this.props.defaultValue} />
               {preamble}
               {error}
               {notifications}
@@ -244,6 +245,7 @@ Index.propTypes = {
   addControl: PropTypes.node,
   attributes: IndexPropTypes.attributes,
   data: IndexPropTypes.data,
+  defaultValue: PropTypes.string,
   emptyMessage: PropTypes.node,
   emptyAddControl: PropTypes.node,
   fill: PropTypes.bool, // for Tiles


### PR DESCRIPTION
Passed defaultValue from Index to Search

We need to be able to pass a default value to the Search component.

The functionality already exists in Search and defaultValue is not a required prop, so it should be backwards compatible
