### PR TITLE
Allow caller to programmatically close filter sidebar

### DIFF
--- a/src/js/components/Index.js
+++ b/src/js/components/Index.js
@@ -30,10 +30,13 @@ export default class Index extends Component {
     super(props, context);
     this._onResponsive = this._onResponsive.bind(this);
     this._toggleInlineFilter = this._toggleInlineFilter.bind(this);
+
+    const {inlineFilterParams = {}} = props;
+    const {isOpen, defaultOpen} = inlineFilterParams;
+
     this.state = {
       responsiveSize: 'medium',
-      inlineFilterOpen:
-        (props.inlineFilterParams && props.inlineFilterParams.isOpen)
+      inlineFilterOpen: isOpen || defaultOpen
     };
   }
 
@@ -268,7 +271,8 @@ Index.propTypes = {
   footer: PropTypes.node,
   inlineFilterParams: PropTypes.shape({
     onToggle: PropTypes.func,
-    isOpen: PropTypes.bool
+    isOpen: PropTypes.bool,
+    defaultOpen: PropTypes.bool // DEPRECATED
   }),
   itemComponent: PropTypes.oneOfType([
     PropTypes.func,

--- a/src/js/components/Index.js
+++ b/src/js/components/Index.js
@@ -33,7 +33,7 @@ export default class Index extends Component {
     this.state = {
       responsiveSize: 'medium',
       inlineFilterOpen:
-        (props.inlineFilterParams && props.inlineFilterParams.defaultOpen)
+        (props.inlineFilterParams && props.inlineFilterParams.isOpen)
     };
   }
 
@@ -44,6 +44,19 @@ export default class Index extends Component {
       console.warn('Using \'onMore\' and \'footer\' props together may ' +
         'cause unexpected behavior.' +
         'Consider removing \'onMore\' functionality when a footer is present.');
+    }
+    const { inlineFilterParams } = this.props;
+    if (inlineFilterParams && inlineFilterParams.defaultOpen) {
+      console.warn('prop inlineFilterParams.defaultOpen has been renamed to ' +
+        'inlineFilterParams.isOpen');
+    }
+  }
+
+  componentWillReceiveProps (nextProps) {
+    const { inlineFilterParams = {} } = this.props;
+    const { inlineFilterParams: nextInlineFilterParams = {} }  = nextProps;
+    if (nextInlineFilterParams.isOpen !== inlineFilterParams.isOpen) {
+      this.setState({ inlineFilterOpen: nextInlineFilterParams.isOpen});
     }
   }
 
@@ -255,7 +268,7 @@ Index.propTypes = {
   footer: PropTypes.node,
   inlineFilterParams: PropTypes.shape({
     onToggle: PropTypes.func,
-    defaultOpen: PropTypes.bool
+    isOpen: PropTypes.bool
   }),
   itemComponent: PropTypes.oneOfType([
     PropTypes.func,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->
#### What does this PR do?

Adds check in `componentWillReceiveProps` to determine if `inlineFilterParams.isOpen` has changed. If so, updates state accordingly. This way, caller can programmatically open or close the sidebar without user interaction.
#### Where should the reviewer start?

review changes in `src/components/Index.js`
#### What testing has been done on this PR?
#### Any background context you want to provide?

We store the display state of the filter sidebar in `localStorage`, which, to support server-side rendering we don't want to check until `componentDidMount`. At this time, grommet-index has already mounted and taken control of the inline filter display state internally.
#### Is this change backwards compatible or is it a breaking change?

Breaking change - I renamed `inlineFilterProps.defaultOpen` to `inlineFilterProps.isOpen` to be more clear since it no longer just sets the default state. I added a `console.warn` in `componentWillMount` to notify consumers.
