### PR TITLE
Fixed attribute pattern in Query

### DIFF
--- a/src/js/utils/Query.js
+++ b/src/js/utils/Query.js
@@ -10,9 +10,9 @@ const TRACE_PARSING = false;
 // value, and lastly with no quotes.
 // We don't build this programmatically for better performance.
 const ATTRIBUTE_PATTERN = new RegExp([
-  `^[^\d:'"\s]{1}[^:'"\s]*:'[^']+'`,
-  `^[^\d:'"\s]{1}[^:'"\s]*:"[^"]+"`,
-  `^[^\d:'"\s]{1}[^:'"\s]*:[^'"\s]+`].join('|'));
+  `^[^\\d:'"\\s]{1}[^:'"\\s]*:'[^']+'`,
+  `^[^\\d:'"\\s]{1}[^:'"\\s]*:"[^"]+"`,
+  `^[^\\d:'"\\s]{1}[^:'"\\s]*:[^'"\\s]+`].join('|'));
 // allow for text to contain quotes
 const TEXT_PATTERN = /^[^'"\s]+|^'[^']+'|^"[^"]+"/;
 


### PR DESCRIPTION
#### What does this PR do?

Fix for #70 
#### Where should the reviewer start?

utils/Query
#### What testing has been done on this PR?

Tested locally with no issues.
#### How should this be manually tested?

Test 2 attributes like `vendor:bluecoat vendor:harambe`
#### Any background context you want to provide?

Query is not functional after release v1.0.0
#### What are the relevant issues?

Query is not working properly.
#### Screenshots (if appropriate)

N/A
#### Do the grommet-index docs need to be updated?

No
#### Should this PR be mentioned in the release notes?

No
#### Is this change backwards compatible or is it a breaking change?

Is intended to be backwards compatible since this restores the original attribute parser.
