### PR TITLE
wrap sort controls in Box to prevent wrapping

### DIFF
--- a/src/js/components/Sort.js
+++ b/src/js/components/Sort.js
@@ -67,7 +67,7 @@ export default class Sort extends Component {
           <select ref="sort" value={this.state.name} onChange={this._onChange}>
             {options}
           </select>
-          <span>
+          <Box direction="row">
             <Button
               icon={<AscIcon
                 colorIndex={'asc' === this.state.direction ?
@@ -78,7 +78,7 @@ export default class Sort extends Component {
                 colorIndex={'desc' === this.state.direction ?
                   'brand' : undefined} />}
               onClick={this._onChangeDirection.bind(this, 'desc')} />
-          </span>
+          </Box>
         </Box>
       </Box>
     );


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Prevents sort buttons from wrapping onto separate lines next to the `select` element.

#### Where should the reviewer start?
`Sort` component

#### What testing has been done on this PR?
Manual UI review

#### Screenshots (if appropriate)
Before: 
![screen shot 2016-11-09 at 9 27 38 am](https://cloud.githubusercontent.com/assets/4998403/20146178/19c21fde-a660-11e6-9ca5-c6f2a32d7570.png)
After:
![screen shot 2016-11-09 at 9 37 50 am](https://cloud.githubusercontent.com/assets/4998403/20146213/350c4a44-a660-11e6-9862-9b3f58a2c06b.png)