### PR TITLE
add onResponsive listener to Index's Split

### DIFF
--- a/src/js/components/Index.js
+++ b/src/js/components/Index.js
@@ -30,13 +30,15 @@ export default class Index extends Component {
     super(props, context);
     this._onResponsive = this._onResponsive.bind(this);
     this._toggleInlineFilter = this._toggleInlineFilter.bind(this);
+    this._onResponsiveFilters = this._onResponsiveFilters.bind(this);
 
     const {inlineFilterParams = {}} = props;
     const {isOpen, defaultOpen} = inlineFilterParams;
 
     this.state = {
       responsiveSize: 'medium',
-      inlineFilterOpen: isOpen || defaultOpen
+      inlineFilterOpen: isOpen || defaultOpen,
+      filtersInline: this.props.filtersInline
     };
   }
 
@@ -69,6 +71,12 @@ export default class Index extends Component {
 
   _onResponsive (small) {
     this.setState({ responsiveSize: (small ? 'small' : 'medium') });
+  }
+
+  _onResponsiveFilters (columns) {
+    if (this.props.filtersInline) {
+      this.setState({filtersInline: columns === 'multiple'});
+    }
   }
 
   _toggleInlineFilter() {
@@ -143,8 +151,7 @@ export default class Index extends Component {
     const ViewComponent = VIEW_COMPONENT[view];
 
     let filterControl;
-    let { filtersInline } = this.props;
-    let { inlineFilterOpen } = this.state;
+    let { inlineFilterOpen, filtersInline } = this.state;
 
     if (filtersInline) {
       filtersInline = filtersInline && this.state.responsiveSize !== 'small';
@@ -195,7 +202,11 @@ export default class Index extends Component {
     return (
       <div className={classes.join(' ')}>
         <div className={`${CLASS_ROOT}__container`}>
-          <Split flex="left" priority="left" fixed={true}>
+          <Split
+            flex="left"
+            priority="left"
+            fixed={true}
+            onResponsive={this._onResponsiveFilters}>
             <div>
               <IndexHeader className={`${CLASS_ROOT}__header`}
                 label={this.props.label}


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Attaches onResponsive to the `Split` to determine which type of filters to display.

#### Where should the reviewer start?
components/Index.js

#### What testing has been done on this PR?
Manual UI review

#### How should this be manually tested?
Resize browser between 800px and 1200px, and you can see that under ~ 1070px wide, the filters are hidden, and there's no way to access them. With this PR, the `onResponsive` updates the component state to determine whether or not the filters can be displayed as a sidebar at the current width.

#### Any background context you want to provide?
Currently with the inline filter sidebar open, you can get into a state (at certain browser widths) where the filters are hidden, and the button to toggle them is also hidden. So, at certain widths, the user has no access to the filters

#### Screenshots (if appropriate)
codepen: https://codepen.io/nickjvm/pen/NbRxGV?&editors=0010