### PR TITLE
update filter/sort heading sizes

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "classnames": "^2.2.3",
     "debounce": "^1.0.0",
-    "grommet": "^1.0.0"
+    "grommet": "^1.2.1"
   },
   "devDependencies": {
     "babel-plugin-add-module-exports": "^0.1.2",

--- a/src/js/components/Filter.js
+++ b/src/js/components/Filter.js
@@ -116,7 +116,7 @@ export default class Filter extends Component {
     const { active } = this.state;
     let boxProps = Props.pick(this.props, Object.keys(Box.propTypes));
 
-    let header = <Heading tag="h3">{label}</Heading>;
+    let header = <Heading tag="h4">{label}</Heading>;
     if (! inline) {
       let summary = this._renderSummary();
       let icon;
@@ -146,7 +146,10 @@ export default class Filter extends Component {
     }
 
     return (
-      <Box {...boxProps} pad={{...boxProps.pad, ...{between: 'small'}}}>
+      <Box
+        {...boxProps}
+        flex={false}
+        pad={{...boxProps.pad, between: 'small'}}>
         {header}
         {choices}
       </Box>

--- a/src/js/components/Filters.js
+++ b/src/js/components/Filters.js
@@ -6,7 +6,9 @@ import Menu from 'grommet/components/Menu';
 import Box from 'grommet/components/Box';
 import Sidebar from 'grommet/components/Sidebar';
 import FilterIcon from 'grommet/components/icons/base/Filter';
+import Heading from 'grommet/components/Heading';
 import Header from 'grommet/components/Header';
+import Footer from 'grommet/components/Footer';
 import Button from 'grommet/components/Button';
 import Filter from './Filter';
 import Sort from './Sort';
@@ -123,7 +125,11 @@ export default class Filters extends Component {
     return (
       <Sidebar colorIndex="light-2">
         <Header size="large" pad={{horizontal: 'medium'}} justify="between">
-          {Intl.getMessage(this.context.intl, 'Filter by')}
+          <Box pad={{horizontal: 'medium'}}>
+            <Heading tag="h3" margin="none">
+              {Intl.getMessage(this.context.intl, 'Filter by')}
+            </Heading>
+          </Box>
           <Box className={`${CLASS_ROOT}__filters`} flex={false}>
             <Button icon={icon} plain={true} onClick={this.props.onClose}/>
             {this._renderCounts()}
@@ -131,11 +137,12 @@ export default class Filters extends Component {
         </Header>
         <Box
           direction={direction}
-          pad={{horizontal: 'large', vertical: 'medium', between: 'medium'}}
+          pad={{horizontal: 'large', between: 'medium'}}
           className={classNames.join(' ')}>
           {filters}
           {sort}
         </Box>
+        <Footer />
       </Sidebar>
     );
   }

--- a/src/js/components/Sort.js
+++ b/src/js/components/Sort.js
@@ -2,6 +2,7 @@
 
 import React, { Component, PropTypes } from 'react';
 import Header from 'grommet/components/Header';
+import Heading from 'grommet/components/Heading';
 import Button from 'grommet/components/Button';
 import Box from 'grommet/components/Box';
 import AscIcon from 'grommet/components/icons/base/LinkDown';
@@ -61,8 +62,10 @@ export default class Sort extends Component {
     let title = Intl.getMessage(this.context.intl, 'Sort');
 
     return (
-      <Box {...boxProps} className={classNames.join(' ')}>
-        <Header size="small">{title}</Header>
+      <Box {...boxProps} flex={false} className={classNames.join(' ')}>
+        <Header size="small">
+          <Heading tag="h4">{title}</Heading>
+        </Header>
         <Box direction="row" justify="between" align="center">
           <select ref="sort" value={this.state.name} onChange={this._onChange}>
             {options}


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Updates filter/sort headings to be more consistent. Also updated `grommet` dependency to 1.2.1 and fixed some flex-shrink issues with inline filters.

### Codepen
https://codepen.io/nickjvm/pen/vgoPrO?editors=0010

**Before**
*sidebar title ('filter by') and sort label are smaller than state & status filter labels.*
![google chromefeb 21 2017 2 33 15 pm](https://cloud.githubusercontent.com/assets/4998403/23186004/ae8be2c4-f842-11e6-95fb-9e1611a0954f.png)
**After**
![google chromefeb 21 2017 2 32 29 pm](https://cloud.githubusercontent.com/assets/4998403/23186005/ae8d6ec8-f842-11e6-9144-cd481d14fe7b.png)
