### PR TITLE
hide "filter by" sidebar heading if no filters exist

### DIFF
--- a/src/js/components/Filters.js
+++ b/src/js/components/Filters.js
@@ -121,14 +121,21 @@ export default class Filters extends Component {
   _renderSidebar ({ filters, sort, classNames }) {
     const { direction } = this.props;
     const icon = this._renderIcon();
+    let heading;
+
+    if (filters.length) {
+      heading = (
+        <Heading tag="h3" margin="none">
+          {Intl.getMessage(this.context.intl, 'Filter by')}
+        </Heading>
+      );
+    }
 
     return (
       <Sidebar colorIndex="light-2">
         <Header size="large" pad={{horizontal: 'medium'}} justify="between">
           <Box pad={{horizontal: 'medium'}}>
-            <Heading tag="h3" margin="none">
-              {Intl.getMessage(this.context.intl, 'Filter by')}
-            </Heading>
+            {heading}
           </Box>
           <Box className={`${CLASS_ROOT}__filters`} flex={false}>
             <Button icon={icon} plain={true} onClick={this.props.onClose}/>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Removes the "Filter By" heading if no filterable attributes exist (ie, only sort attributes are set)

#### What testing has been done on this PR?
Manual UI testing via codepen, http://codepen.io/nickjvm/pen/vgoPrO?editors=0010

#### How should this be manually tested?
In the code pen, remove the "status" filter attribute from the `attributes` const. See that "Filter by" is removed from the view.

#### Screenshots (if appropriate)
**only sort**
![google chromemar 9 2017 9 11 50 am](https://cloud.githubusercontent.com/assets/4998403/23759075/ec0eb870-04a8-11e7-840d-dbf105fcf711.png)
**with filterable attributes**
![google chromemar 9 2017 9 11 43 am](https://cloud.githubusercontent.com/assets/4998403/23758918/74726334-04a8-11e7-990f-7466b6e15da3.png)


#### Is this change backwards compatible or is it a breaking change?
No breaking changes