### PR TITLE
update to grommet v1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "classnames": "^2.2.3",
     "debounce": "^1.0.0",
-    "grommet": "^1.2.1"
+    "grommet": "^1.3.0"
   },
   "devDependencies": {
     "babel-plugin-add-module-exports": "^0.1.2",

--- a/src/js/components/Filters.js
+++ b/src/js/components/Filters.js
@@ -133,23 +133,26 @@ export default class Filters extends Component {
 
     return (
       <Sidebar colorIndex="light-2">
-        <Header size="large" pad={{horizontal: 'medium'}} justify="between">
-          <Box pad={{horizontal: 'medium'}}>
-            {heading}
+        <Box full>
+          <Header size="large" pad={{horizontal: 'medium'}} justify="between">
+            <Box pad={{horizontal: 'medium'}}>
+              {heading}
+            </Box>
+            <Box className={`${CLASS_ROOT}__filters`} flex={false}>
+              <Button icon={icon} plain={true} onClick={this.props.onClose}/>
+              {this._renderCounts()}
+            </Box>
+          </Header>
+          <Box
+            flex={false}
+            direction={direction}
+            pad={{horizontal: 'large', between: 'medium'}}
+            className={classNames.join(' ')}>
+            {filters}
+            {sort}
           </Box>
-          <Box className={`${CLASS_ROOT}__filters`} flex={false}>
-            <Button icon={icon} plain={true} onClick={this.props.onClose}/>
-            {this._renderCounts()}
-          </Box>
-        </Header>
-        <Box
-          direction={direction}
-          pad={{horizontal: 'large', between: 'medium'}}
-          className={classNames.join(' ')}>
-          {filters}
-          {sort}
+          <Footer />
         </Box>
-        <Footer />
       </Sidebar>
     );
   }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Updates Grommet dependency version to latest, and fixes overflow scrolling issue when height of filters overflows the sidebar that was present after Grommet update.

**Good**
![google chromemar 16 2017 10 11 33 am](https://cloud.githubusercontent.com/assets/4998403/24006306/0508d882-0a31-11e7-9a06-5ea11b6b7762.png)

**Bad**
![google chromemar 16 2017 10 10 44 am](https://cloud.githubusercontent.com/assets/4998403/24006307/0511e5ee-0a31-11e7-951a-b9bf31b1569a.png)