### PR TITLE
Add style to hide select drop arrow on IE11

### DIFF
--- a/src/scss/grommet-index/_objects.index-sort.scss
+++ b/src/scss/grommet-index/_objects.index-sort.scss
@@ -1,0 +1,7 @@
+// (C) Copyright 2014-2015 Hewlett Packard Enterprise Development LP
+
+.index-sort {
+  select::-ms-expand {
+    display: none;
+  }
+}

--- a/src/scss/grommet-index/index.scss
+++ b/src/scss/grommet-index/index.scss
@@ -8,3 +8,4 @@
 @import "objects.index-filters";
 @import "objects.index-header";
 @import "objects.index-table";
+@import "objects.index-sort";


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes double arrow for select element in IE11. This is a stop-gap since index should be using Grommet's Sort component.

![virtualboxvm__win10 first run running screen shot apr 21 2017 10 33 05 am](https://cloud.githubusercontent.com/assets/473729/25287263/f71da50e-267d-11e7-98a6-1860d4164ea8.png)