### PR TITLE
Use ref callbacks instead; remove unused refs

### DIFF
--- a/src/js/components/Index.js
+++ b/src/js/components/Index.js
@@ -227,7 +227,7 @@ export default class Index extends Component {
               {error}
               {notifications}
               <Box pad={{between: 'medium'}}>
-                <div ref="items" className={`${CLASS_ROOT}__items`}>
+                <div className={`${CLASS_ROOT}__items`}>
                   <ViewComponent
                     actions={this.props.actions}
                     attributes={this.props.attributes}

--- a/src/js/components/Sort.js
+++ b/src/js/components/Sort.js
@@ -67,7 +67,7 @@ export default class Sort extends Component {
           <Heading tag="h4">{title}</Heading>
         </Header>
         <Box direction="row" justify="between" align="center">
-          <select ref="sort" value={this.state.name} onChange={this._onChange}>
+          <select value={this.state.name} onChange={this._onChange}>
             {options}
           </select>
           <Box direction="row">


### PR DESCRIPTION
This PR removes named refs that are [now deprecated](https://facebook.github.io/react/docs/refs-and-the-dom.html#legacy-api-string-refs). If refs are needed, the callback syntax should be used instead.