### PR TITLE
use data.error to display error message

### DIFF
--- a/src/js/components/Index.js
+++ b/src/js/components/Index.js
@@ -109,7 +109,7 @@ export default class Index extends Component {
     if (data && data.error) {
       error = (
         <div className={`${CLASS_ROOT}__error`}>
-          {result.error}
+          {data.error}
         </div>
       );
     }


### PR DESCRIPTION
should pull `error` off of `data`, not `result`.